### PR TITLE
Improve doc: `to_dask_array(lengths=True)` is the key part

### DIFF
--- a/docs/source/array-chunks.rst
+++ b/docs/source/array-chunks.rst
@@ -107,7 +107,7 @@ Unknown chunksizes also occur when using a Dask DataFrame to create a Dask array
    >>> ddf.to_dask_array()
    dask.array<..., shape=(nan, 2), ..., chunksize=(nan, 2)>
 
-Using :func:`~dask.dataframe.DataFrame.to_dask_array` resolves this issue:
+Using :func:`~dask.dataframe.DataFrame.to_dask_array` with `lengths=True` resolves this issue by triggering computation of the chunk sizes:
 
 .. code-block:: python
 


### PR DESCRIPTION
Clarify that it's the `lengths=True` keyword passed to `to_dask_array` that triggers computation of the chunk sizes and allows the message about 'unknown chunk size' to be addressed.

The current statement is that `to_dask_array()` doesn't work, but `to_dask_array()` can fix the problem.  That doesn't literally make sense and isn't what's meant.  I think the intent of the sentence is to introduce the `lengths=True` option and say that `to_dask_array(lengths=True)` can solve the problem, when a simple `to_dask_array()` does not.

- [ ] Tests added / passed.
  Pure documentation change.
- [X] Passes `black dask` / `flake8 dask`.
  The changes pass `black` and `flake8`.  The `master` of `dask` doesn't pass `black` and `flake8` with the default settings on my machine, but that doesn't seem important to this present PR.
